### PR TITLE
Fix incorrect token generation format

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -119,7 +119,7 @@ class BasePayment(models.Model):
         if not self.token:
             tries = {}  # Stores a set of tried values
             while True:
-                token = uuid4().hex
+                token = str(uuid4())
                 if token in tries and len(tries) >= 100:  # After 100 tries we are impliying an infinite loop
                     raise SystemExit('A possible infinite loop was detected')
                 else:


### PR DESCRIPTION
uuid4().hex does not generate the expected uuid format required by `process_payment` url
